### PR TITLE
Fixing app build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Zeppelin is a collaborative data analytic and visualization tool for distributed
 1. NodeJS with npm
 2. Bower
 
-You can used 
- * bower install 
- * npm install
+Run
+ * `npm install` first
+ * `bower install` then
+
 This will Download all the dependencies including node js and npm
 
 ### Build the application

--- a/bower
+++ b/bower
@@ -14,4 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"node/node" "./node_modules/bower/bin/bower" "$@"
+node="node/node"
+
+if hash "node" 2>/dev/null ; then
+  node="node"
+fi
+"${node}" "./node_modules/bower/bin/bower" "$@"

--- a/grunt
+++ b/grunt
@@ -14,5 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"node/node" "./node_modules/.bin/grunt" "$@"
+node="node/node"
+
+if hash "node" 2>/dev/null ; then
+  node="node"
+fi
+"$node" "./node_modules/.bin/grunt" "$@"
 

--- a/grunt
+++ b/grunt
@@ -19,5 +19,5 @@ node="node/node"
 if hash "node" 2>/dev/null ; then
   node="node"
 fi
-"$node" "./node_modules/.bin/grunt" "$@"
+"${node}" "./node_modules/.bin/grunt" "$@"
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^3.0.0",
+    "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "karma-jasmine": "*",
     "karma-phantomjs-launcher": "*",
     "load-grunt-tasks": "^3.1.0",
-    "time-grunt": "^1.0.0"
+    "time-grunt": "^1.0.0",
+    "bower": "1.4.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Could not build:
- ./grunt was not executable
- ./grunt did not use `node` in the path
- node_modules/.bin missing `grunt` as grunt-cli was not installed

And I still have 

```
./grunt build
Running "clean:dist" (clean) task
>> 0 paths cleaned.

Running "wiredep:app" (wiredep) task
Warning: Error: Cannot find where you keep your Bower packages. Use --force to continue.

Aborted due to warnings.


Execution Time (2015-06-26 02:45:00 UTC)
loading tasks    8ms  ▇▇▇▇ 3%
clean:dist      15ms  ▇▇▇▇▇▇ 5%
wiredep:app    276ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 92%
Total 299ms
```
